### PR TITLE
corrected the description of the productCreatedTs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -240,8 +240,8 @@ The structure describing "Authoritative Definitions" is shared between all Bitol
 
 ## Other Properties
 
-| Key              | Key | UX label            | Required | Description                                                             |
-|------------------|-----|---------------------|----------|-------------------------------------------------------------------------|
-| productCreatedTs |     | Product Created UTC | No       | Timestamp in UTC of when the data contract was created, using ISO 8601. |
+| Key              | Key | UX label            | Required | Description                                                            |
+|------------------|-----|---------------------|----------|------------------------------------------------------------------------|
+| productCreatedTs |     | Product Created UTC | No       | Timestamp in UTC of when the data product was created, using ISO 8601. |
 
 All trademarks are the property of their respective owners. 

--- a/schema/odps-json-schema-v1.0.0.json
+++ b/schema/odps-json-schema-v1.0.0.json
@@ -97,7 +97,7 @@
     "productCreatedTs": {
       "type": "string",
       "format": "date-time",
-      "description": "Timestamp in UTC of when the data contract was created, using ISO 8601."
+      "description": "Timestamp in UTC of when the data product was created, using ISO 8601."
     }
   },
   "$defs": {


### PR DESCRIPTION
The original description in the bitol ODPS for the productCreatedTs in the files docs/README.md and schema/odps-json-schema-v1.0.0.json was "Timestamp in UTC of when the data **contract** was created, using ISO 8601." and its been changed to "Timestamp in UTC of when the data **product** was created, using ISO 8601."


**Files affected:**
1. docs/README.md
2.  schema/odps-json-schema-v1.0.0.json