### PR TITLE
chore: add Apache-2.0 / SPDX headers to source files

### DIFF
--- a/.github/workflows/docs-site-deploy.yaml
+++ b/.github/workflows/docs-site-deploy.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: docs-site-deploy
 on:
   push:

--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: validate-examples
 on:
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@ description: "How you can contribute to the Open Data Product Standard (ODPS)."
 image: "https://raw.githubusercontent.com/bitol-io/artwork/main/horizontal/color/Bitol_Logo_color.svg"
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Contributing to Open Data Product Standard
 
 Thank you for your interest in contributing to Open Data Product Standard (ODPS). Please refer to the [TSC contributing guidelines](https://github.com/bitol-io/tsc/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ description: "Home of Open Data Product Standard (ODPS) documentation."
 image: "https://raw.githubusercontent.com/bitol-io/artwork/main/horizontal/color/Bitol_Logo_color.svg"
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8149/badge)](https://www.bestpractices.dev/projects/8149)
 <a href="https://github.com/bitol-io/open-data-product-standard">
 <img alt="Stars" src="https://img.shields.io/github/stars/bitol-io/open-data-product-standard" /></a>

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,11 @@ description: "Details of the Open Data Product Standard (ODPS). Includes fundame
 image: "https://raw.githubusercontent.com/bitol-io/artwork/main/horizontal/color/Bitol_Logo_color.svg"
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Open Data Product Standard
 
 ## Executive Summary

--- a/docs/authoritative-definitions.md
+++ b/docs/authoritative-definitions.md
@@ -3,6 +3,11 @@ title: "Authoritative Definitions"
 description: "Reference external sources of truth from a data product."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Authoritative Definitions
 
 Authoritative Definitions are an essential part of the data product. They allow to delegate the definition or authority to a third-party system like an enterprise catalog, repository, etc. The structure describing authoritative definitions is shared between all Bitol standards and follows the [ODCS Authoritative Definitions structure](https://bitol-io.github.io/open-data-contract-standard/latest/authoritative-definitions/). This block is available in many sections.

--- a/docs/context.md
+++ b/docs/context.md
@@ -3,6 +3,11 @@ title: "Context"
 description: "AI and semantic context guidance for the data product."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Context
 
 Added in **ODPS v1.1.0** (RFC-0038). The `context` block provides structured, human- and machine-readable guidance for AI agents, LLMs, BI tools, and semantic layer platforms. It is optional and additive.

--- a/docs/custom-other-properties.md
+++ b/docs/custom-other-properties.md
@@ -3,6 +3,11 @@ title: "Custom & Other Properties"
 description: "Custom properties and other properties of the data product."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Custom & Other Properties
 
 This section covers custom properties and other properties you may find in a data product.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Examples
 
 This directory contains examples of Open Data Product Standard (ODPS) files.

--- a/docs/examples/customer-data-product.odps.yaml
+++ b/docs/examples/customer-data-product.odps.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1.1.0
 kind: DataProduct
 

--- a/docs/examples/simple-data-product.odps.yaml
+++ b/docs/examples/simple-data-product.odps.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1.1.0
 kind: DataProduct
 id: 064c4630-8aad-4dc0-ba95-0f69940e6b18

--- a/docs/fundamentals.md
+++ b/docs/fundamentals.md
@@ -3,6 +3,11 @@ title: "Fundamentals"
 description: "Fundamental identifying information for the data product."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Fundamentals
 
 The core metadata section defines the fundamental identifying information required for the data product.

--- a/docs/management-ports.md
+++ b/docs/management-ports.md
@@ -3,6 +3,11 @@ title: "Management Ports"
 description: "Access points for managing the data product."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Management Ports
 
 The management ports define access points for managing the data product.

--- a/docs/product-information.md
+++ b/docs/product-information.md
@@ -3,6 +3,11 @@ title: "Product Information"
 description: "Input and output ports of the data product."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Product Information
 
 Describe the core of the product, including the input and output ports.

--- a/docs/support-communication-channels.md
+++ b/docs/support-communication-channels.md
@@ -3,6 +3,11 @@ title: "Support and Communication Channels"
 description: "Support and communication channels for the data product."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Support and Communication Channels
 
 The structure describing support and communication channels is shared between all Bitol standards and follows the [ODCS Support & Communication Channels structure](https://bitol-io.github.io/open-data-contract-standard/latest/support-communication-channels/).

--- a/docs/team.md
+++ b/docs/team.md
@@ -3,6 +3,11 @@ title: "Team"
 description: "The team responsible for the data product."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Team
 
 The structure describing the team is shared between all Bitol standards and follows the [ODCS Team structure](https://bitol-io.github.io/open-data-contract-standard/latest/team/), matching RFC 0016.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 site_name: Open Data Product Standard
 site_url: https://bitol-io.github.io/open-data-product-standard/
 repo_url: https://github.com/bitol-io/open-data-product-standard

--- a/resources.md
+++ b/resources.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Articles & Other Resources
 
 ## Articles

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # ODPS JSON Schema
 
 You will find all the versions of the Open Data Product Standard (ODPS) JSON Schema files here. Each version will be 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # ODPS Validation Scripts
 
 This directory contains validation scripts for the Open Data Product Standard (ODPS), following the exact pattern from the [Open Data Contract Standard (ODCS)](https://github.com/bitol-io/open-data-contract-standard) repository.

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 echo "Moving top level markdown files into 'docs' folder"
 cat README.md | sed 's/(docs\//(/g' | sed 's/CONTRIBUTING.md/contributing.md/g' | sed 's/resources.md/\.\.\/resources.md/g' > docs/home.md
 cat CHANGELOG.md | sed 's/(docs\//(/g' > docs/changelog.md

--- a/scripts/validate-examples.sh
+++ b/scripts/validate-examples.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'


### PR DESCRIPTION
Adds a uniform copyright + SPDX header to every project-authored Markdown, YAML, shell, and config file:

\`\`\`
Copyright 2026 The Bitol Contributors
SPDX-License-Identifier: Apache-2.0
\`\`\`

### Form per language
- **Markdown** — HTML comment, placed after YAML front-matter when present (so MkDocs metadata parsing is preserved)
- **YAML / mkdocs / GitHub workflows** — \`#\` comment at top of file
- **Shell scripts** — \`#\` comment after the shebang

### Skipped
- \`schema/*.json\` and \`package.json\` — JSON has no comment syntax, and the versioned schemas are released artifacts whose bytes shouldn't change retroactively. The repo-level \`LICENSE\` covers them.
- \`LICENSE\`, \`AUTHORS.md\`, \`CHANGELOG.md\` — by Apache / LF convention

### Notes
- Wording follows LF norms: *The Bitol Contributors* (vendor-neutral, no per-file company copyrights, no "All rights reserved").
- 22 files changed, +96 / −0 (no incidental line-ending normalization this time).
- Mirrors the same change in [open-data-contract-standard#280](https://github.com/bitol-io/open-data-contract-standard/pull/280).

🤖 Generated with [Claude Code](https://claude.com/claude-code)