### PR TITLE
docs: dedicate ODPS v1.1.0 to Peter Flook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ image: "https://raw.githubusercontent.com/bitol-io/artwork/main/horizontal/color
 
 This document tracks the history and evolution of the **Open Data Product Standard**.
 
-# v1.1.0 - DRAFT
+# v1.1.0 "Peter Flook" - DRAFT
+
+This release is dedicated to the memory of our friend and longtime contributor **Peter Flook**, whose work shaped the Bitol standards — from data quality testing to schema validation, documentation, and vendor onboarding. We carry his contributions forward in this version and beyond.
 
 * Add optional top-level `type` field categorising data products by architectural alignment (e.g., `sourceAligned`, `aggregate`, `consumerAligned`) — RFC-0029.
 * Add optional `context` block at the data product and output port levels for AI / semantic interoperability (instructions, verifiedStatements, constraints) — RFC-0038, shared with ODCS v3.2.0.

--- a/history.md
+++ b/history.md
@@ -1,0 +1,19 @@
+# History
+
+## Version 1.1.x — "Peter Flook"
+ODPS v1.1.0 is dedicated to the memory of our friend and longtime contributor **Peter Flook**. Peter's work touched many parts of the Bitol ecosystem: data quality, schema validation, documentation, vendor onboarding, and so much more. This release carries his name in gratitude.
+
+ODPS v1.1.0 is currently in development. Tracked RFCs are listed in the [`tsc/rfcs/`](https://github.com/bitol-io/tsc/tree/main/rfcs) directory.
+
+## Version 1.0.x
+ODPS v1.0.0 aligned the standard with ODCS v3.1.0 — team structure, authoritative definitions, and shared sections — and added `customProperties`, `tags`, and `authoritativeDefinitions` to input and output ports.
+
+ODPS v1.0.0 was released in September 2025.
+
+## Version 0.9.x
+The first approved release of the Open Data Product Standard, establishing the core data product structure.
+
+ODPS v0.9.0 was released in July 2025.
+
+## Early Versions
+ODPS started as a very early draft in 2023, part of the discussions that led to the creation of [Bitol](https://bitol.io) within the [Linux Foundation AI & Data](https://lfaidata.foundation/). Bitol englobes ODCS, ODPS, and future standards & tools.


### PR DESCRIPTION
Mirrors the ODCS v3.2.0 "Peter Flook" tribute on the ODPS v1.1.0 line — ODPS didn't have the matching dedication.

- **CHANGELOG.md**: rename the release to `v1.1.0 "Peter Flook"` with a dedication paragraph.
- **history.md**: new file mirroring the ODCS `history.md` (which ODPS lacked), with the v1.1.x dedication and the ODPS version lineage (1.0.x, 0.9.x, early versions).

Kept as a root file to match ODCS (not in the mkdocs nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)